### PR TITLE
🗑️remove: unused geist font settings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove references to Geist font variables in the global CSS theme configuration