### PR TITLE
🧰chore: remove TURBOPACK=1 env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ COPY --from=builder /usr/src/app/.next/standalone ./
 COPY --from=builder /usr/src/app/.next/static ./.next/static
 
 EXPOSE 3000
-ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000 TURBOPACK=1
+ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000
 ENTRYPOINT ["/nodejs/bin/node", "server.js"]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "TURBOPACK=1 bun .next/standalone/server.js",
+    command: "bun .next/standalone/server.js",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove TURBOPACK=1 environment variable from project configuration files