### PR TITLE
♻️refactor: replace the all `bunx` with `bun`

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun update
 
       - name: 🔷 Run Biome
-        run: bun lint && bunx biome ci --reporter=github
+        run: bun lint && bun biome ci --reporter=github
 
       - name: 💾 Commit
         uses: autofix-ci/action@v1.3.1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,10 +52,10 @@ jobs:
         run: bun run build
 
       - name: 🎭 Install Playwright Browsers
-        run: bunx playwright install --with-deps
+        run: bun playwright install --with-deps
 
       - name: 🧪 Run Playwright tests
-        run: bunx playwright test
+        run: bun playwright test
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "dev-win": "WATCHPACK_POLLING=true next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start --turbopack",
-    "lint": "bunx biome check --write",
+    "lint": "bun biome check --write",
     "test:app": "bun test test/app",
     "test:e2e": "bun playwright test",
-    "test:report": "bunx playwright show-report"
+    "test:report": "bun playwright show-report"
   },
   "dependencies": {
     "next": "canary",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update project scripts and GitHub workflows to use `bun` instead of `bunx` for command execution