### PR TITLE
🆙bump: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.15.1-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.16.0-rc1-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -148,7 +148,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.34", "", { "os": "win32", "cpu": "x64" }, "sha512-O62ej/i66UeXZBK7dHmmupc/IcbYwLgfca1V2uuF3349qQJCu7TCxjX/oOcWNE4nZGy5uNOZ6cTzUPgYLA81nA=="],
 
-    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-14", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-14" }, "bin": { "playwright": "cli.js" } }, "sha512-+Rx64EkOaIiFPHXNOYnheURlQ4ZRTiyz7tTaRB0nx54GYEnoHigL3UCP6hp/3Lnvp/Wm5UyTVUIdNQ7orsoVUQ=="],
+    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-15", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-15" }, "bin": { "playwright": "cli.js" } }, "sha512-YholhgqMxH/VJ2w6iHKryNSrpoQySyyql7dOGnTo96qcZFUBjiIbOrollQi5zHdQadwTMLtujvh7tXMgmz052g=="],
 
     "@rspack/binding": ["@rspack/binding@1.3.9", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.3.9", "@rspack/binding-darwin-x64": "1.3.9", "@rspack/binding-linux-arm64-gnu": "1.3.9", "@rspack/binding-linux-arm64-musl": "1.3.9", "@rspack/binding-linux-x64-gnu": "1.3.9", "@rspack/binding-linux-x64-musl": "1.3.9", "@rspack/binding-win32-arm64-msvc": "1.3.9", "@rspack/binding-win32-ia32-msvc": "1.3.9", "@rspack/binding-win32-x64-msvc": "1.3.9" } }, "sha512-3FFen1/0F2aP5uuCm8vPaJOrzM3karCPNMsc5gLCGfEy2rsK38Qinf9W4p1bw7+FhjOTzoSdkX+LFHeMDVxJhw=="],
 
@@ -228,7 +228,7 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-ccdb475-20250513", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-CYycfikXKgFz4C5yti3qYIXz81d3ZDPf6hvzuQuTkuyfcpVrXCEqHawotCMxy7UeF75Z50OknqofFjvwHi3S0Q=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-52ea7f9-20250514", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Q2Y1uEyE8LY/XGI4Bm/zJ5EIUhS3zoqyNJWHg2DFMc5tPacCEKvAdSAPMTXsc7Vfdi5JmqH7ZN9pxITaYowZDA=="],
 
     "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
@@ -316,9 +316,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.53.0-alpha-2025-05-14", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-14" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-B1ZhOHEOyqEJ/7PrfxmP7SQWimnqHEnVkQ+ZPfv2sPoeNbB8kyICO6aXTndnDElkU/weeFBliRkGflnWjxeH6g=="],
+    "playwright": ["playwright@1.53.0-alpha-2025-05-15", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-15" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-zVh+dkJz/lBc2AIFgeqwqJlLB6nIRKRA/0S8sSet/7t6KAF7lWTzzzHqFogF2llP1huG0h5SiLv/RF+LvRAWpQ=="],
 
-    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-14", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-vW0GoWnW4MGo9a6njq63KykhVg7MYOVs+73qB6QbILJPBfQDuHik2b70bIPMMHis87IHVqzwSj+vdqHgXO0M4g=="],
+    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-15", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-1UQa+uMv32QliMXjIJIppkQaNQkm+pMp7pTThQmN7TAz3NP2Ik9r8vvdcaWDPbakYybNVkNWB6h5CW6uCscC9g=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Update project dependencies by bumping Dockerfile syntax version and regenerating the lock file

Enhancements:
- Bump Dockerfile upstream syntax from 1.15.1-labs to 1.16.0-rc1-labs
- Refresh bun.lock to capture updated dependency versions