### PR TITLE
Potential fix for code scanning alert no. 6: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,12 +55,13 @@ jobs:
 
       - name: 🧪 Test app
         run: |
-          bun test:app &> >(tee -p test.log) || echo STATUS=$(echo $? | tr -d '\n') >> $GITHUB_ENV
+          bun test:app &> >(tee -p test.log) || STATUS=$(echo $? | grep -E '^[0-9]+$' || echo 1)
+          echo "STATUS=$STATUS" >> $GITHUB_ENV
           UUID=$(uuidgen)
           {
-            echo 'RESULT<<EOF$UUID'
+            echo "RESULT<<EOF$UUID"
             cat test.log
-            echo 'EOF$UUID'
+            echo "EOF$UUID"
           } >> $GITHUB_ENV
 
       - name: 💬 Create test comment


### PR DESCRIPTION
Potential fix for [https://github.com/OpenUp-LabTakizawa/rasnage/security/code-scanning/6](https://github.com/OpenUp-LabTakizawa/rasnage/security/code-scanning/6)

To address the issue, we need to ensure that the `STATUS` environment variable is set in a way that prevents any potential injection of malicious content. This can be achieved by explicitly sanitizing the value before appending it to `$GITHUB_ENV`. Since the `STATUS` variable is derived from the exit code of the `bun test:app` command, we can safely restrict it to numeric values using a validation step.

Additionally, for the multiline environment variable `RESULT`, we should use a unique delimiter to prevent injection attacks. This ensures that any untrusted data cannot prematurely close the `EOF` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sourceryによるサマリー

`STATUS`変数を数値のみに制限し、GitHub Actionsワークフローの`RESULT`ブロックに一意のデリミタを使用することで、環境変数インジェクションの脆弱性を防止します。

バグ修正:
- `STATUS`を`$GITHUB_ENV`に追加する前に、数字のみであることを検証し、悪意のあるコンテンツのインジェクションを防止します。
- 複数行の`RESULT`変数ブロックに一意のEOFデリミタを採用し、早期終了とインジェクションのリスクを回避します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize the STATUS variable to numeric values and use a unique delimiter for the RESULT block in the GitHub Actions workflow to prevent environment variable injection vulnerabilities.

Bug Fixes:
- Validate and restrict STATUS to digits before appending to $GITHUB_ENV to prevent malicious content injection
- Adopt a unique EOF delimiter for the multiline RESULT variable block to avoid premature termination and injection risks

</details>