### PR TITLE
🆙bump: update dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -130,25 +130,25 @@
 
     "@module-federation/webpack-bundler-runtime": ["@module-federation/webpack-bundler-runtime@0.13.1", "", { "dependencies": { "@module-federation/runtime": "0.13.1", "@module-federation/sdk": "0.13.1" } }, "sha512-QSuSIGa09S8mthbB1L6xERqrz+AzPlHR6D7RwAzssAc+IHf40U6NiTLPzUqp9mmKDhC5Tm0EISU0ZHNeJpnpBQ=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.48", "", {}, "sha512-W/5lNgUPf8IeIFPTo3nkU/YEs2QWnkJ40oqIqMV36YkhcQcKQ73J5Y/fizMiVh2cKa422XUgBfzqgfqbiW0x6Q=="],
+    "@next/env": ["@next/env@15.4.0-canary.52", "", {}, "sha512-WLCC+OfAAhl7yD4k+s0Lp2Kmrx7BUTfzBvpootbwXGl3tiOKQEOFEAx2xQH71MvuS+QRzctV2guQ7n/OlR41Kg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AvRyLO90nNlR1yC6bS5684NWif6gIQYVmrSALnWXAfx/Cr9khxWyEOZTMyajKI2RLy+1IcsDEeiWJC/Ko/jlew=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.52", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AirTVuz0DdSagf+dMXFrFij+4CxgjzjPitIWn85SQQReb3vLQ49Z77OiE9v4mq4cZWmkGNf+L66PCh9b+u0gAQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.48", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vt6ZGpr7vvCMHF5tdp+Bf4rtBT4RWf0i46y5nLN5RygwdKXOfvdeitMo3pzOkqnBJC/YQPxB4ETyHyZ9u+BAVw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.52", "", { "os": "darwin", "cpu": "x64" }, "sha512-dODJDDZDvN7yDg5v4IGUsXRTiDnO669LjH8c1ClivzIdB3AmUJ+8a6G4xv5fJp2AHDmyj7g6LCYCNc/cEAiiSw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ow2Ficccp9tCS5iC99Z7s1Lel7sHN+CXwZ89OD8TaFfOUkwNX9yJFa8sfrIEaEq6Q9gOCJIYa+Iev491DjjEtQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-DdEjMMbce2xkssx30nh0LHY/U3yQTPOm96eg3AbyBv+InExnbjUYtx4RAw1NKLsfuyIynT9FgNPehBuEjLxtTg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-r/zoG+ubjZgSkwTOK2Nd/KWDu/TluChZo+YtEGWYXcMfgCSGzPFKxP8E/WGIN1DCHsZPh9tdln8rqTFRg3OMGg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-4kTj/W3/c10pDEsy91lvnsJ/VDAn5hESPcTeLQvFmUVu6p54DcJ4MhpuRRhUl/+3osY5dwkc9zG3/R9BkOSwRA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.48", "", { "os": "linux", "cpu": "x64" }, "sha512-mXUm+j+XG3EIiBPVnVh7zQEpPjhb8cSqe1xQSHbG2gtt57/gltKwqgJRqahNK5PvgpaqZ+0Y8n0kiRuWOFPFCw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-7g3P6NqDDh52ydRmUlTAV4FrSPsXUousbKf5RDM0D/118hlFn7DRordjYs0LyB5PP+uVRGLjEQFHQ/wi/dNY6A=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.48", "", { "os": "linux", "cpu": "x64" }, "sha512-mpJHZKGc8eTP2ZhkE8IZbMMIVFxlkQEGIYnhVFer/MHk2N9rMb7xr9wRdmtQe1/2xWaequnJjecBbVVdSqBfjg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-5qCSO0xAmPVRIql+HLY9Utl/vkUSzgrH14t8yOl0gZtB0B4DABSUUJ8yuzr3ET/YrrEckGUcYutgFoo5Ao2VWw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.48", "", { "os": "win32", "cpu": "arm64" }, "sha512-kLk9u6Lal58FZKZRqnjYE8yr4wdm9cdFuqhRwkf4h43FbmcD9Vh42uF49JUNWCKB2DGB3tn28RZvqWZBarmMXg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.52", "", { "os": "win32", "cpu": "arm64" }, "sha512-GRgmB/03fsQbSQguxrNGYOeY+n4IoEbKyCDh/ftPIh9KiCE6BzanVSIxgJom7ir3c0Lyz8LNTNJSIq2XDMXp3w=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.48", "", { "os": "win32", "cpu": "x64" }, "sha512-8cinbntzXOJVaC4smWqTWnSN+t8PRHUHThKSJml9j9sIfzNkabdBcksfflHWYzJmg1NLvfvTixyADR5gOIDH9g=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.52", "", { "os": "win32", "cpu": "x64" }, "sha512-vrX3kaJWQBbDApALLB7nQZongAg+uhkw0OBq9AK+GT/1dcW1XvarJYktGvOmNMLfkOIDbRrz68wjTt98/BU1CA=="],
 
-    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-23", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-23" }, "bin": { "playwright": "cli.js" } }, "sha512-WdTIHB2I5IuBs8q/CSnjauuhm3o1sShdgO+lKCncRh0nD24PTyyUiE8yBrq4OazrX1toGHlawV1HwEIdrq+fcg=="],
+    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-26", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-26" }, "bin": { "playwright": "cli.js" } }, "sha512-RFN0MGA2LOiDa+9eewLfWcfHCHwPbA2cUr8YnJmHK51XfNemJvFFgg9xn0ttg9ncN8V2rFXQtrG2B1YTWXUPQA=="],
 
     "@rspack/binding": ["@rspack/binding@1.3.9", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.3.9", "@rspack/binding-darwin-x64": "1.3.9", "@rspack/binding-linux-arm64-gnu": "1.3.9", "@rspack/binding-linux-arm64-musl": "1.3.9", "@rspack/binding-linux-x64-gnu": "1.3.9", "@rspack/binding-linux-x64-musl": "1.3.9", "@rspack/binding-win32-arm64-msvc": "1.3.9", "@rspack/binding-win32-ia32-msvc": "1.3.9", "@rspack/binding-win32-x64-msvc": "1.3.9" } }, "sha512-3FFen1/0F2aP5uuCm8vPaJOrzM3karCPNMsc5gLCGfEy2rsK38Qinf9W4p1bw7+FhjOTzoSdkX+LFHeMDVxJhw=="],
 
@@ -228,7 +228,7 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-f980e29-20250522", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-H1ZXNJ3HJhO5X16lj0BXNWgj/rRx0DQAztXzkBCoVO2BYrwNHqeecaa8zQkkNkxc9+BXKYw2LwSnkz5dCEfYdQ=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-8f8b1db-20250523", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-0ESQ3EQIoFm6ZNjmvfJFbqyEpbGT6TwinwTutgjS7b8PH7hQ3Hd8B43OwbAwb7bgpt/VsfSnqPsRp25HzwlU1Q=="],
 
     "bun-types": ["bun-types@1.2.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA=="],
 
@@ -310,15 +310,15 @@
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "next": ["next@15.4.0-canary.48", "", { "dependencies": { "@next/env": "15.4.0-canary.48", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.48", "@next/swc-darwin-x64": "15.4.0-canary.48", "@next/swc-linux-arm64-gnu": "15.4.0-canary.48", "@next/swc-linux-arm64-musl": "15.4.0-canary.48", "@next/swc-linux-x64-gnu": "15.4.0-canary.48", "@next/swc-linux-x64-musl": "15.4.0-canary.48", "@next/swc-win32-arm64-msvc": "15.4.0-canary.48", "@next/swc-win32-x64-msvc": "15.4.0-canary.48", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-sVphJz0rAyhi/SbkmB7fgII+1TevN7OkQRXjf3739rgc+41HVdNwXXThfyLALGKI89ZtIBRT5Jf4APKLekioCA=="],
+    "next": ["next@15.4.0-canary.52", "", { "dependencies": { "@next/env": "15.4.0-canary.52", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.52", "@next/swc-darwin-x64": "15.4.0-canary.52", "@next/swc-linux-arm64-gnu": "15.4.0-canary.52", "@next/swc-linux-arm64-musl": "15.4.0-canary.52", "@next/swc-linux-x64-gnu": "15.4.0-canary.52", "@next/swc-linux-x64-musl": "15.4.0-canary.52", "@next/swc-win32-arm64-msvc": "15.4.0-canary.52", "@next/swc-win32-x64-msvc": "15.4.0-canary.52", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-A8Jv61u5x29ySMakrF+qDCp/Sy4J7H6OPa7gxcz3tCB9Y98a6ebAUShWVIvZYJJ7WGLXeQ74qMbmdKff2be3MQ=="],
 
-    "next-rspack": ["next-rspack@15.4.0-canary.48", "", { "dependencies": { "@rspack/core": "1.3.9", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-+aZ75K5mej2AnwuiWgdObrirMWBl6ybQHYjkpV0HDXucIxHS1TOZSWPkQUzaeYT37Xy0wrI7pJUxaeDS2d1oDA=="],
+    "next-rspack": ["next-rspack@15.4.0-canary.52", "", { "dependencies": { "@rspack/core": "1.3.9", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-bvCRFcfSz9zV15KvrN6VfdR9dpiz4CU9bfbQcncLrEBnfn3OHh+41lh3LQG0NUgp7amb/SFi/60hzqiCzXOIHg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.53.0-alpha-2025-05-23", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-23" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-86hfHKdPcBAjDguEb6doNG76uj2fUbFBCCqew4/0KwOnLrpAPJ2Uyeygt+zsj2k9ok+n7NWtsbpxSmXj6kYieA=="],
+    "playwright": ["playwright@1.53.0-alpha-2025-05-26", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-26" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-1lLjQtDXCl30cYryndHTa7dF/gX4C4GbruVLlSWo/gq8ok/HK3jyN/mBZeFRPFOgtgVolZj3YbRgAs5Zb9NKxQ=="],
 
-    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-23", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-60XHM1EGJl5ugdUwMNYbmJoj6zTAAZO0Rr5OTApFwj2gqQC5vERbB6XewD8a2MbxAMXVaZThKFcABr1VZi6NkQ=="],
+    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-26", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-UG1IYdcpPrZXp63ezudm7VQTIyJJoiNX0VhjS1UsBUpG5dxXcEKMxoKuXKfj8EOeW0g9zezjdx+BDrPpO2Vv9g=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 


### PR DESCRIPTION
## Sourcery によるサマリー

雑務：
- 更新された依存関係のバージョンを反映するために、bun.lock を再生成します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regenerate bun.lock to reflect updated dependency versions.

</details>