### PR TITLE
♻️chore: change dependabot node ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       ci:
         patterns:
           - "*"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "daily"

--- a/bun.lock
+++ b/bun.lock
@@ -148,7 +148,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.56", "", { "os": "win32", "cpu": "x64" }, "sha512-NKKYd9cC4hpw8JVQajgyEktVKAWZ4BXtLVRHSKJCOjWYDV3uNkwufj6f48bBArjvcmsvxjbtKmFS4iQPt4Wxxw=="],
 
-    "@playwright/test": ["@playwright/test@1.53.0-alpha-1748463427000", "", { "dependencies": { "playwright": "1.53.0-alpha-1748463427000" }, "bin": { "playwright": "cli.js" } }, "sha512-xXAzUCnubdNXg2d3/XCctVGPEdlIBWh/T42KhsBujTqUgzalNurEG0ceqnhsQ/pia8wjvplYq90SdldKoLicHA=="],
+    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-29", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-29" }, "bin": { "playwright": "cli.js" } }, "sha512-wz6xE5Kfph9hfN+FaRfWpQ79bXTXzdk/0xqPlOdd48UOTD0ONrXcIsI9qsyAxU5IJy/tLTJR2sAW7GSIdV/qmw=="],
 
     "@rspack/binding": ["@rspack/binding@1.3.12", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.3.12", "@rspack/binding-darwin-x64": "1.3.12", "@rspack/binding-linux-arm64-gnu": "1.3.12", "@rspack/binding-linux-arm64-musl": "1.3.12", "@rspack/binding-linux-x64-gnu": "1.3.12", "@rspack/binding-linux-x64-musl": "1.3.12", "@rspack/binding-win32-arm64-msvc": "1.3.12", "@rspack/binding-win32-ia32-msvc": "1.3.12", "@rspack/binding-win32-x64-msvc": "1.3.12" } }, "sha512-4Ic8lV0+LCBfTlH5aIOujIRWZOtgmG223zC4L3o8WY/+ESAgpdnK6lSSMfcYgRanYLAy3HOmFIp20jwskMpbAg=="],
 
@@ -316,9 +316,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.53.0-alpha-1748463427000", "", { "dependencies": { "playwright-core": "1.53.0-alpha-1748463427000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Sohm8IXDcTSsGNjQdKwxdhKbHYdik484lg/rVekS43/DkAkRGXrYYGki4kx+eom5DxjkIuSVzz/NQ6X+aYrw7A=="],
+    "playwright": ["playwright@1.53.0-alpha-2025-05-29", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-29" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-P14kUb/SHOkSbthDmojGjyJiwaXfwOLo2R8fuWTuuAqBllTJ/sQkbYcg+0HvFld8F1ZYoKTQr2doJukX/XITng=="],
 
-    "playwright-core": ["playwright-core@1.53.0-alpha-1748463427000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-t8S3ReYivb+aJwcji08vASrDGVpWS5m3UP4Dqvfu/CgzJKZ03UTjYu3Iz95+UcO/UQH2dy1JEL7I5AvobXPBmQ=="],
+    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-29", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-hH0CLzWMrAYUWBDmQi4W8JOcrSX/WkSvOlRQIkzMZmFeaTS0Iv/BHl76xgMc1P+z/N3kj6rxPNii5kkYYJneaQ=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 


### PR DESCRIPTION
## Sourcery によるサマリー

Dependabot の設定を更新し、Bun エコシステムを使用して毎日の依存関係の更新を行い、Bun lockfile を追加します。

雑務:
- Dependabot のパッケージエコシステムを、依存関係の更新のために npm から bun に切り替えました
- Bun の依存関係の追跡を有効にするために、bun.lock をリポジトリに追加しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Dependabot configuration to use the Bun ecosystem for daily dependency updates and add the Bun lockfile.

Chores:
- Switch Dependabot package ecosystem from npm to bun for dependency updates
- Add bun.lock to the repository to enable Bun dependency tracking

</details>